### PR TITLE
changed header height and homepage background image calc

### DIFF
--- a/components/sections/Header.tsx
+++ b/components/sections/Header.tsx
@@ -19,8 +19,9 @@ const Header = () => (
       align="center"
       justify={["center", "center", "center", "space-between", "space-between"]}
       wrap="wrap"
-      padding={["8px", "8px", "1rem", "2rem", "2rem"]}
+      padding={["8px", "8px", "8px", "1rem", "1rem"]}
       bg="black"
+      height={["170px", "170px", "170px", "78px", "78px"]}
     >
       <Flex
         align="center"
@@ -55,7 +56,7 @@ const Header = () => (
 
       {/* Smaller screen size display */}
       <Stack
-        spacing={3}
+        spacing={2}
         direction="column"
         display={["block", "block", "block", "none", "none"]}
       >
@@ -69,7 +70,7 @@ const Header = () => (
             onSubmit={() => undefined}
           />
         </Flex>
-        <Stack justify="center" direction="row">
+        <Stack spacing={2} justify="center" direction="row">
           <HeaderButton>Post Listing</HeaderButton>
           <HeaderButton borderColor="white">Get Started</HeaderButton>
         </Stack>

--- a/components/sections/HeaderHome.tsx
+++ b/components/sections/HeaderHome.tsx
@@ -22,8 +22,9 @@ const HeaderHome = () => (
       "space-between",
     ]}
     wrap="wrap"
-    padding={["8px", "8px", "2rem", "2rem", "2rem"]}
+    padding={["8px", "8px", "1rem", "1rem", "1rem"]}
     bg="black"
+    height={["110px", "110px", "78px", "78px", "78px"]}
   >
     <Flex
       align="center"
@@ -45,15 +46,17 @@ const HeaderHome = () => (
 
     {/* Smaller screen size display */}
     <Stack
-      spacing={3}
+      spacing={2}
       direction="column"
       display={["block", "block", "none", "none", "none"]}
     >
       <Flex justify="center">
         <LogoWhite width="150px" background="black" />
       </Flex>
-      <HeaderButton>Post Listing</HeaderButton>
-      <HeaderButton borderColor="white">Get Started</HeaderButton>
+      <Stack spacing={2} justify="center" direction="row">
+        <HeaderButton>Post Listing</HeaderButton>
+        <HeaderButton borderColor="white">Get Started</HeaderButton>
+      </Stack>
     </Stack>
   </Flex>
 );

--- a/components/sections/HeaderWhite.tsx
+++ b/components/sections/HeaderWhite.tsx
@@ -19,8 +19,9 @@ const Header = () => (
       align="center"
       justify={["center", "center", "center", "space-between", "space-between"]}
       wrap="wrap"
-      padding={["8px", "8px", "1rem", "2rem", "2rem"]}
+      padding={["8px", "8px", "8px", "1rem", "1rem"]}
       bg="white"
+      height={["170px", "170px", "170px", "78px", "78px"]}
     >
       <Flex
         align="center"
@@ -55,7 +56,7 @@ const Header = () => (
 
       {/* Smaller screen size display */}
       <Stack
-        spacing={3}
+        spacing={2}
         direction="column"
         display={["block", "block", "block", "none", "none"]}
       >
@@ -69,7 +70,7 @@ const Header = () => (
             onSubmit={() => undefined}
           />
         </Flex>
-        <Stack justify="center" direction="row">
+        <Stack spacing={2} justify="center" direction="row">
           <HeaderButton bg="white" color="black">Post Listing</HeaderButton>
           <HeaderButton borderColor="white">Get Started</HeaderButton>
         </Stack>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -18,7 +18,13 @@ function HomePage(): ReactElement {
       <Flex
         align="center"
         bgImage="url('/bg1.jpg')"
-        height="calc(100vh - 110px)"
+        height={[
+          "calc(100vh - 110px)",
+          "calc(100vh - 110px)",
+          "calc(100vh - 78px)",
+          "calc(100vh - 78px)",
+          "calc(100vh - 78px)",
+        ]}
         bgPosition="25% 75%"
         bgRepeat="no-repeat"
         bgSize="cover"


### PR DESCRIPTION
Thinner header that correspond more to Figma image + background image height calculation based on screen size.

![image](https://user-images.githubusercontent.com/43283387/112043608-3b4bc300-8b1f-11eb-95a5-60b95e279a74.png)
