### PR TITLE
fix: improve white header positioning

### DIFF
--- a/components/sections/HeaderWhite.tsx
+++ b/components/sections/HeaderWhite.tsx
@@ -1,16 +1,9 @@
 import React from "react";
-import { chakra, Flex, Stack } from "@chakra-ui/react";
-import { ButtonPrimary } from "@/components/core/Button";
+import { Flex, Stack } from "@chakra-ui/react";
+import { ButtonPrimary, ButtonSecondary } from "@/components/core/Button";
 import { LogoBlack } from "@/components/core/Branding";
 
 import SearchInput from "@/components/core/SearchInput";
-
-const HeaderButton = chakra(ButtonPrimary, {
-  baseStyle: {
-    bg: "black",
-    _hover: { bg: "gray" },
-  },
-});
 
 const Header = () => (
   <>
@@ -24,7 +17,9 @@ const Header = () => (
       bg="white"
       height={["170px", "170px", "170px", "78px", "78px"]}
       boxShadow="md"
-      position="absolute"
+      position="sticky"
+      top={0}
+      zIndex={1000}
     >
       <Flex
         align="center"
@@ -53,10 +48,8 @@ const Header = () => (
         marginRight="64px"
         display={["none", "none", "none", "block", "block"]}
       >
-        <HeaderButton bg="white" color="black">
-          Post Listing
-        </HeaderButton>
-        <HeaderButton borderColor="white">Get Started</HeaderButton>
+        <ButtonSecondary>Post Listing</ButtonSecondary>
+        <ButtonPrimary>Get Started</ButtonPrimary>
       </Stack>
 
       {/* Smaller screen size display */}
@@ -76,10 +69,8 @@ const Header = () => (
           />
         </Flex>
         <Stack spacing={2} justify="center" direction="row">
-          <HeaderButton bg="white" color="black">
-            Post Listing
-          </HeaderButton>
-          <HeaderButton borderColor="white">Get Started</HeaderButton>
+          <ButtonSecondary>Post Listing</ButtonSecondary>
+          <ButtonPrimary>Get Started</ButtonPrimary>
         </Stack>
       </Stack>
     </Flex>

--- a/pages/listings/[id].tsx
+++ b/pages/listings/[id].tsx
@@ -68,7 +68,7 @@ function ListingPage(
       </Head>
       <HeaderWhite />
       <ImageCarousel images={images} />
-      <ContainerPrimary paddingY="0.5in">
+      <ContainerPrimary>
         <Grid
           gridTemplateColumns={["100%", "100%", "100%", "auto 4in"]}
           gridTemplateRows="min-content"
@@ -78,7 +78,8 @@ function ListingPage(
             gridColumn="1"
             gridRow={["2", "2", "2", "1"]}
             spacing="2.5rem"
-            paddingY={[0, 0, 0, "0.5in"]}
+            paddingTop={[0, 0, 0, "1in"]}
+            paddingBottom={["0.5in", "0.5in", "0.5in", "1in"]}
           >
             <Box>
               <Caption>{city}</Caption>
@@ -140,7 +141,12 @@ function ListingPage(
             </Box>
           </Stack>
           <Box gridColumn={["1", "1", "1", "2"]} gridRow="1">
-            <Box position="sticky" top={0} paddingY={[0, 0, 0, "0.5in"]}>
+            <Box
+              position="sticky"
+              top={0}
+              paddingTop={["0.5in", "0.5in", "0.5in", "1in"]}
+              paddingBottom={[0, 0, 0, "1in"]}
+            >
               <ListingContactCard
                 price={price}
                 firstName={poster.firstName}

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -132,123 +132,121 @@ function Search(props: SearchProps): ReactElement {
         <title>Yōkoso</title>
         <meta name="description" content="ようこそ. Discover your new home." />
       </Head>
-      <HeaderWhite />
-      <Flex
-        paddingTop={["170px", "170px", "170px", "78px", "78px"]}
-        column={2}
-        height="100vh"
-        bg="white"
-        overflow="hidden"
-      >
-        <Box flex={[1, 1, 1, 1, 0.9]} row={3} overflowY="scroll" maxW="700px">
-          <Box flex="1" p="5">
-            <Heading4>Listings in {location?.locationName}</Heading4>
-          </Box>
-          <SimpleGrid flex="1" p="4" spacing={[0, 0, 1, 2, 2]} columns={4}>
-            <SingleFilter
-              name="Price"
-              isOpen={isOpenPrice}
-              onOpen={onOpenPrice}
-              onClose={onClosePrice}
-              childComp={
-                <SliderFilter
-                  max={2100}
-                  min={0}
-                  value={priceFilter}
-                  onChange={(val) => setPriceFilter(val)}
-                />
-              }
-            />
-
-            <SingleFilter
-              name="Rooms"
-              isOpen={isOpenRooms}
-              onOpen={onOpenRooms}
-              onClose={onCloseRooms}
-              childComp={
-                <CounterFilter
-                  value={rooms}
-                  onClickAdd={() => (rooms < 15 ? setRooms(rooms + 1) : null)}
-                  onClickMinus={() => (rooms > 1 ? setRooms(rooms - 1) : null)}
-                />
-              }
-            />
-            <SingleFilter
-              name="Bathrooms"
-              isOpen={isOpenBathroom}
-              onOpen={onOpenBathroom}
-              onClose={onCloseBathroom}
-              childComp={
-                <CounterFilter
-                  value={bathrooms}
-                  onClickAdd={() =>
-                    bathrooms < 99 ? setBathroom(bathrooms + 1) : null
-                  }
-                  onClickMinus={() =>
-                    bathrooms > 1 ? setBathroom(bathrooms - 1) : null
-                  }
-                />
-              }
-            />
-
-            <ButtonSecondaryVariant
-              maxW="140px"
-              padding="9px"
-              onClick={onFilterOpen}
-            >
-              Other
-            </ButtonSecondaryVariant>
-            <FilterModals isOpen={isFilterOpen} onClose={onFilterClose} />
-          </SimpleGrid>
-          <Divider />
-          <Box flex="1" overflow="auto" w="100%">
-            {listings.map((listing: ListingType, index) => (
-              <LgSearchResult
-                key={index}
-                imageUrl={listing.imageUrl}
-                location={listing.location.city}
-                price={listing.price}
-                numBaths={listing.numBaths}
-                numBeds={listing.numBeds}
-                id={listing.key}
-                title={listing.title}
-                display={["none", "block", "none", "block", "block"]}
-                width="100%"
+      <Box height="100vh" overflow="hidden">
+        <HeaderWhite />
+        <Flex column={2} height="100%" bg="white">
+          <Box flex={[1, 1, 1, 1, 0.9]} row={3} overflowY="scroll" maxW="700px">
+            <Box flex="1" p="5">
+              <Heading4>Listings in {location?.locationName}</Heading4>
+            </Box>
+            <SimpleGrid flex="1" p="4" spacing={[0, 0, 1, 2, 2]} columns={4}>
+              <SingleFilter
+                name="Price"
+                isOpen={isOpenPrice}
+                onOpen={onOpenPrice}
+                onClose={onClosePrice}
+                childComp={
+                  <SliderFilter
+                    max={2100}
+                    min={0}
+                    value={priceFilter}
+                    onChange={(val) => setPriceFilter(val)}
+                  />
+                }
               />
-            ))}
-          </Box>
-          <Box flex="1" paddingTop={4} overflow="auto" w="100%">
-            {listings.map((listing: ListingType, index) => (
-              <SmSearchResult
-                key={index}
-                imageUrl={listing.imageUrl}
-                location={listing.location.city}
-                price={listing.price}
-                numBaths={listing.numBaths}
-                numBeds={listing.numBeds}
-                id={listing.key}
-                title={listing.title}
-                display={["block", "none", "block", "none", "none"]}
-                width="100%"
+
+              <SingleFilter
+                name="Rooms"
+                isOpen={isOpenRooms}
+                onOpen={onOpenRooms}
+                onClose={onCloseRooms}
+                childComp={
+                  <CounterFilter
+                    value={rooms}
+                    onClickAdd={() => (rooms < 15 ? setRooms(rooms + 1) : null)}
+                    onClickMinus={() =>
+                      rooms > 1 ? setRooms(rooms - 1) : null
+                    }
+                  />
+                }
               />
-            ))}
+              <SingleFilter
+                name="Bathrooms"
+                isOpen={isOpenBathroom}
+                onOpen={onOpenBathroom}
+                onClose={onCloseBathroom}
+                childComp={
+                  <CounterFilter
+                    value={bathrooms}
+                    onClickAdd={() =>
+                      bathrooms < 99 ? setBathroom(bathrooms + 1) : null
+                    }
+                    onClickMinus={() =>
+                      bathrooms > 1 ? setBathroom(bathrooms - 1) : null
+                    }
+                  />
+                }
+              />
+
+              <ButtonSecondaryVariant
+                maxW="140px"
+                padding="9px"
+                onClick={onFilterOpen}
+              >
+                Other
+              </ButtonSecondaryVariant>
+              <FilterModals isOpen={isFilterOpen} onClose={onFilterClose} />
+            </SimpleGrid>
+            <Divider />
+            <Box flex="1" overflow="auto" w="100%">
+              {listings.map((listing: ListingType, index) => (
+                <LgSearchResult
+                  key={index}
+                  imageUrl={listing.imageUrl}
+                  location={listing.location.city}
+                  price={listing.price}
+                  numBaths={listing.numBaths}
+                  numBeds={listing.numBeds}
+                  id={listing.key}
+                  title={listing.title}
+                  display={["none", "block", "none", "block", "block"]}
+                  width="100%"
+                />
+              ))}
+            </Box>
+            <Box flex="1" paddingTop={4} overflow="auto" w="100%">
+              {listings.map((listing: ListingType, index) => (
+                <SmSearchResult
+                  key={index}
+                  imageUrl={listing.imageUrl}
+                  location={listing.location.city}
+                  price={listing.price}
+                  numBaths={listing.numBaths}
+                  numBeds={listing.numBeds}
+                  id={listing.key}
+                  title={listing.title}
+                  display={["block", "none", "block", "none", "none"]}
+                  width="100%"
+                />
+              ))}
+            </Box>
           </Box>
-        </Box>
-        <Box
-          flex={[0, 0, 1, 1, 1.25]}
-          display={["none", "none", "block", "block", "block"]}
-          position="relative"
-          maxW="100%"
-        >
-          <Map
-            defaultLat={43.65107}
-            defaultLong={-79.347015}
-            // defaultLat={location.latitude}
-            // defaultLong={location.longitude}
-            listings={listings}
-          />
-        </Box>
-      </Flex>
+          <Box
+            flex={[0, 0, 1, 1, 1.25]}
+            display={["none", "none", "block", "block", "block"]}
+            position="relative"
+            maxW="100%"
+          >
+            <Map
+              defaultLat={43.65107}
+              defaultLong={-79.347015}
+              // defaultLat={location.latitude}
+              // defaultLong={location.longitude}
+              listings={listings}
+            />
+          </Box>
+        </Flex>
+      </Box>
     </>
   );
 }


### PR DESCRIPTION
The white header was changed to absolute positioning which meant the element was not part of the normal flow of the page (e.g. does not push following elements down). This caused the header to take up the same space as the image carousel on the property details page and be behind it, in this case, with only the input button being visible.

![image](https://user-images.githubusercontent.com/20251243/113494872-ab146300-94ba-11eb-8cce-a649ea86ade7.png)

Pages modified (link using staging environment):

- https://d2l3ad90rail6x.cloudfront.net/search
- https://d2l3ad90rail6x.cloudfront.net/listings/id

Changes:

- resolve header not showing up on property details page
- refactor search page so header height is not hard-coded as padding offset
- use standard buttons in white header

Note:

- `search.tsx` shows a lot of white space changes in the diff. The only real changes are on lines 135 to 137 where mainly padding top was removed in favor of styles that automatically adjust to the height of the page