### PR TITLE
fix: fix chat error when there are no messages

### DIFF
--- a/components/sections/ChatMessagingArea.tsx
+++ b/components/sections/ChatMessagingArea.tsx
@@ -323,7 +323,7 @@ function ChatMessagingArea(props: {
 
   const currentRoomCollection = chatRoomsCollection?.docs[
     currentChatRoomIdx || 0
-  ].data() as ChatRoom | undefined;
+  ]?.data() as ChatRoom | undefined;
   // Take most recent associated listing
   const associatedListing =
     currentRoomCollection &&


### PR DESCRIPTION
Uses optional chaining to avoid calling function on undefined chat collection.

Now when there are no messages, it continues on as normal and shows the following instead of throwing an error:

![image](https://user-images.githubusercontent.com/20251243/138028616-c0a954e5-1a9d-4de6-9274-21469e288e76.png)

Thanks to @meganhng for catching the issue.