### PR TITLE
cd: update serverless component to 3.6.0

### DIFF
--- a/serverless-production.yml
+++ b/serverless-production.yml
@@ -1,7 +1,7 @@
 name: yokoso-production
 
 yokoso-production:
-  component: "@sls-next/serverless-component@1.18.0"
+  component: "@sls-next/serverless-component@3.6.0"
   inputs:
     build:
       cmd: "npm"

--- a/serverless-staging.yml
+++ b/serverless-staging.yml
@@ -1,7 +1,7 @@
 name: yokoso-staging
 
 yokoso-staging:
-  component: "@sls-next/serverless-component@1.18.0"
+  component: "@sls-next/serverless-component@3.6.0"
   inputs:
     build:
       cmd: "npm"


### PR DESCRIPTION
Updates serverless component to v3.6.0 to *hopefully* fix the `ResourceConflictException` on Lambda functions during deployment after a semi-recent AWS update that changed their behavior. This should resolve the [current broken deployment](https://github.com/yokoso-capstone/yokoso/runs/4275032684?check_suite_focus=true) on the staging environment (dev branch).

Version 3.6.0 is the latest release version at time of the commit.

Tested a deployment with fresh/temp resources.

See https://github.com/serverless-nextjs/serverless-next.js/issues/1976 for more details.