### PR TITLE
fix: improve header sign-in photo

### DIFF
--- a/components/sections/DashboardHeader.tsx
+++ b/components/sections/DashboardHeader.tsx
@@ -1,5 +1,9 @@
-import React, { ReactElement } from "react";
+import React, { ReactElement, useEffect, useMemo, useState } from "react";
 import { Box, Flex, Stack, IconButton, chakra, Image } from "@chakra-ui/react";
+import { useAuthState } from "react-firebase-hooks/auth";
+import { auth } from "../../src/firebase";
+import { usersPublic } from "../../src/api/collections";
+import { UserPublic } from "../../src/api/types";
 import { Heading4 } from "../core/Text";
 import NotificationBellSvg from "../svg/notification-bell.svg";
 
@@ -11,6 +15,25 @@ interface DashboardHeaderProps {
 
 function DashboardHeader(props: DashboardHeaderProps): ReactElement {
   const { title } = props;
+
+  const [user] = useAuthState(auth);
+  const query = useMemo(() => (user ? usersPublic.doc(user.uid) : undefined), [
+    user,
+  ]);
+  const [photoUrl, setPhotoUrl] = useState("");
+
+  useEffect(() => {
+    const getPhotoUrl = async () => {
+      if (query) {
+        const userPublicDoc = await query.get();
+        const userPublicData = userPublicDoc.data() as UserPublic;
+
+        setPhotoUrl(userPublicData.profilePicture);
+      }
+    };
+
+    getPhotoUrl();
+  }, [query]);
 
   return (
     <Box
@@ -52,12 +75,7 @@ function DashboardHeader(props: DashboardHeaderProps): ReactElement {
             width="44px"
             height="44px"
             isRound
-            icon={
-              <Image
-                borderRadius="full"
-                src="https://placekitten.com/300/300"
-              />
-            }
+            icon={<Image borderRadius="full" src={photoUrl} />}
           />
         </Stack>
       </Flex>

--- a/components/sections/Header.tsx
+++ b/components/sections/Header.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import React, { ReactElement, useEffect, useMemo, useState } from "react";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
 import {
@@ -11,7 +11,6 @@ import {
   IconButton,
   Image,
   Divider,
-  Center
 } from "@chakra-ui/react";
 import { ButtonPrimary, ButtonSecondary } from "@/components/core/Button";
 import { LogoWhite, LogoBlack } from "@/components/core/Branding";
@@ -23,6 +22,8 @@ import Login from "@/components/sections/Login";
 import Signup from "@/components/sections/Signup";
 import { auth } from "@/src/firebase";
 import { useAuthState } from "react-firebase-hooks/auth";
+import { usersPublic } from "@/src/api/collections";
+import { UserPublic } from "@/src/api/types";
 import RoutePath, { RoutePathDashboard } from "@/src/routes";
 
 const darkThemeSecondaryButtonProps: ButtonProps = {
@@ -51,6 +52,11 @@ function Header(props: HeaderProps): ReactElement {
   const background = darkTheme ? "black" : "white";
 
   const [user] = useAuthState(auth);
+  const query = useMemo(() => (user ? usersPublic.doc(user.uid) : undefined), [
+    user,
+  ]);
+  const [photoUrl, setPhotoUrl] = useState("");
+
   const { isOpen, onToggle } = useDisclosure();
   const {
     isOpen: isOpenLogin,
@@ -79,6 +85,19 @@ function Header(props: HeaderProps): ReactElement {
       onOpenLogin();
     }
   };
+
+  useEffect(() => {
+    const getPhotoUrl = async () => {
+      if (query) {
+        const userPublicDoc = await query.get();
+        const userPublicData = userPublicDoc.data() as UserPublic;
+
+        setPhotoUrl(userPublicData.profilePicture);
+      }
+    };
+
+    getPhotoUrl();
+  }, [query]);
 
   return (
     <>
@@ -148,22 +167,20 @@ function Header(props: HeaderProps): ReactElement {
               >
                 Get Started
               </ButtonPrimary>
-              <Center height="50px">
-                <Divider orientation="vertical" />
-              </Center>
               {user && (
-                <IconButton
-                  aria-label="Profile"
-                  width="44px"
-                  height="44px"
-                  isRound
-                  icon={
-                    <Image
-                      borderRadius="full"
-                      src="https://placekitten.com/300/300"
-                    />
-                  }
-                />
+                <>
+                  <Box height="auto" px={2}>
+                    <Divider orientation="vertical" />
+                  </Box>
+                  <IconButton
+                    aria-label="Profile"
+                    width="44px"
+                    height="44px"
+                    isRound
+                    onClick={handleGetStarted}
+                    icon={<Image borderRadius="full" src={photoUrl} />}
+                  />
+                </>
               )}
             </Stack>
             <Box display={["block", "block", "block", "none"]} cursor="pointer">

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "format:check": "prettier --check '**/*'.{js,ts,tsx,css} --ignore-path .gitignore",
     "lint": "eslint . -c .eslintrc.json --ext js,jsx,ts,tsx --ignore-path .eslintignore",
     "lint-fix": "eslint . -c .eslintrc.json --ext js,jsx,ts,tsx --ignore-path .eslintignore --fix",
-    "test:unit:components": "jest components/__tests__",
+    "test:unit:components": "env-cmd -e staging jest components/__tests__",
     "test:unit:firestore": "jest test/unit/firestore",
     "cypress": "cypress open",
     "cypress:all": "cypress run"

--- a/src/api/collections.ts
+++ b/src/api/collections.ts
@@ -1,5 +1,5 @@
-import firebaseConfig from "@/src/firebaseConfig";
-import { firestore } from "@/src/firebase";
+import firebaseConfig from "../firebaseConfig";
+import { firestore } from "../firebase";
 
 export enum CollectionName {
   ChatRooms = "chat-rooms",

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -2,7 +2,7 @@ import firebase from "firebase/app";
 import "firebase/analytics";
 import "firebase/auth";
 import "firebase/firestore";
-import firebaseConfig from "@/src/firebaseConfig";
+import firebaseConfig from "./firebaseConfig";
 
 if (!firebase.apps.length) {
   firebase.initializeApp(firebaseConfig);


### PR DESCRIPTION
Main header improvements with sign-in photo:

- show divider only when there is photo to divide
- get photo URL from database
- go to dashboard when clicked
- increase spacing around divider

Also improves on dashboard header where it used to use a hard-coded profile photo.

Resolves #79 