### PR TITLE
feat: add tenant and landlord view switching 

### DIFF
--- a/components/dashboard/RentalView.tsx
+++ b/components/dashboard/RentalView.tsx
@@ -1,0 +1,7 @@
+import { ReactElement } from "react";
+
+function RentalView(): ReactElement {
+  return <></>;
+}
+
+export default RentalView;

--- a/components/dashboard/RequestView.tsx
+++ b/components/dashboard/RequestView.tsx
@@ -42,6 +42,8 @@ import {
   listingRouteBuilder,
   listingHrefBuilder,
 } from "@/src/utils/listingRoute";
+import { useStore } from "@/src/store";
+import { UserType } from "@/src/enum";
 import { Heading5 } from "../core/Text";
 
 enum Request {
@@ -56,12 +58,12 @@ interface DeleteProps {
 }
 
 function RequestView(): ReactElement {
-  const [selectedRequest, setSelectedRequest] = useState<Request>(
-    Request.Received
-  );
   const [tenantRequestList, setTenantRequestList] = useState<
     TenantRequestEntry[]
   >([]);
+  const userType = useStore((state) => state.userType);
+  const selectedRequest =
+    userType && userType === UserType.Tenant ? Request.Sent : Request.Received;
 
   const [user] = useAuthState(auth);
   const query = useMemo(
@@ -81,6 +83,7 @@ function RequestView(): ReactElement {
             selectedRequest === Request.Received ? "tenantUid" : "landlordUid"
           ]
         );
+
         return {
           ...publicUserInfo,
           ...requestData,
@@ -93,27 +96,21 @@ function RequestView(): ReactElement {
       }
     };
 
-    handleTenantRequestPromise();
-  }, [user, snapshot]);
+    if (selectedRequest) {
+      handleTenantRequestPromise();
+    }
+  }, [selectedRequest, snapshot]);
 
   return (
     <DashboardCard>
       <Tabs isLazy>
         <TabList>
-          <TabPrimary
-            onClick={() => {
-              setSelectedRequest(Request.Received);
-            }}
-          >
-            Received
+          <TabPrimary>
+            {selectedRequest && selectedRequest === Request.Received
+              ? "Received"
+              : "Sent"}
           </TabPrimary>
-          <TabPrimary
-            onClick={() => {
-              setSelectedRequest(Request.Sent);
-            }}
-          >
-            Sent
-          </TabPrimary>
+
           <Spacer />
           <Box marginTop="8px" marginBottom="16px">
             <DashboardSearchInput />

--- a/components/dashboard/StartView.tsx
+++ b/components/dashboard/StartView.tsx
@@ -1,0 +1,97 @@
+import { ReactElement, useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import {
+  HStack,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  Radio,
+  RadioGroup,
+} from "@chakra-ui/react";
+import { ButtonPrimary } from "@/components/core/Button";
+import { Body1, Heading5 } from "@/components/core/Text";
+import RoutePath, { RoutePathDashboard } from "@/src/routes";
+import { UserType } from "@/src/enum";
+import { getUserType } from "@/src/localStorage";
+import { useStore } from "@/src/store";
+
+function StartView(): ReactElement {
+  const userTypeLS = getUserType();
+  const userTypeStore = useStore((state) => state.userType);
+  const setUserTypeStore = useStore((state) => state.setUserType);
+  const [userTypeRadio, setUserTypeRadio] = useState(UserType.Tenant);
+  const router = useRouter();
+
+  const isModalOpened = !userTypeLS;
+
+  const handleGoToDashboard = () => {
+    setUserTypeStore(userTypeRadio);
+  };
+
+  useEffect(() => {
+    if (userTypeLS) {
+      setUserTypeStore(userTypeLS);
+    }
+  }, [userTypeLS, setUserTypeStore]);
+
+  useEffect(() => {
+    if (userTypeStore) {
+      // Tabs to bring the user to when initially loading the dashboard
+      const defaultRoute =
+        userTypeStore === UserType.Tenant
+          ? RoutePathDashboard.Rentals
+          : RoutePathDashboard.Listings;
+
+      router.push(`${RoutePath.Dashboard}/${defaultRoute}`);
+    }
+  }, [userTypeStore, router]);
+
+  return (
+    <Modal
+      // no-op function that makes the linter happy :)
+      onClose={Function.prototype()}
+      isOpen={isModalOpened}
+      isCentered
+      size="xs"
+    >
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>
+          <Heading5>
+            Hello!{" "}
+            <span role="img" aria-label="waving hand">
+              👋
+            </span>
+          </Heading5>
+        </ModalHeader>
+        <ModalBody>
+          <Body1>
+            Are you interested as a tenant or as a landlord? Choosing helps show
+            you the most relevant content and you can always switch it later in
+            the sidebar.
+          </Body1>
+          <RadioGroup
+            onChange={(nextValue) => setUserTypeRadio(nextValue as UserType)}
+            value={userTypeRadio}
+            my={4}
+          >
+            <HStack spacing={4}>
+              <Radio value={UserType.Tenant}>Tenant</Radio>
+              <Radio value={UserType.Landlord}>Landlord</Radio>
+            </HStack>
+          </RadioGroup>
+        </ModalBody>
+        <ModalFooter>
+          <ButtonPrimary onClick={handleGoToDashboard} isFullWidth>
+            Go to dashboard
+          </ButtonPrimary>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}
+
+export default StartView;

--- a/components/sections/ChatMessagingArea.tsx
+++ b/components/sections/ChatMessagingArea.tsx
@@ -154,7 +154,7 @@ const Header = (props: {
             textOverflow="ellipsis"
           >
             {listing
-              ? `Interested in your "${listing.details.title} listing" at ${
+              ? `Interested in "${listing.details.title} listing" at ${
                   listing.location.unitNumber
                     ? `${listing.location.unitNumber} `
                     : ""

--- a/components/sections/DashboardHeader.tsx
+++ b/components/sections/DashboardHeader.tsx
@@ -10,7 +10,7 @@ import NotificationBellSvg from "../svg/notification-bell.svg";
 export const NotificationBell = chakra(NotificationBellSvg);
 
 interface DashboardHeaderProps {
-  title: string;
+  title?: string;
 }
 
 function DashboardHeader(props: DashboardHeaderProps): ReactElement {

--- a/components/sections/Sidebar.tsx
+++ b/components/sections/Sidebar.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import NextLink from "next/link";
-import { chakra, Flex, Icon, Link } from "@chakra-ui/react";
+import { useRouter } from "next/router";
+import { Flex, Icon, Link, Stack, Switch, chakra } from "@chakra-ui/react";
 import {
   BsFillHouseDoorFill,
   BsFillPersonFill,
@@ -9,12 +10,14 @@ import {
 import { IconType } from "react-icons/lib";
 import { ButtonPrimary, SideBarButton } from "@/components/core/Button";
 import { LogoWhite } from "@/components/core/Branding";
-import RoutePath, { RoutePathDashboard } from "@/src/routes";
+import { Body2 } from "@/components/core/Text";
+import RoutePath, { RoutePathDashboard, pathMapping } from "@/src/routes";
 import { auth } from "@/src/firebase";
-import { DashboardLabel } from "@/src/enum";
+import { DashboardLabel, UserType } from "@/src/enum";
+import { useStore } from "@/src/store";
 
 interface SidebarProps {
-  activeDashboardPath: RoutePathDashboard;
+  activeDashboardPath?: RoutePathDashboard;
 }
 
 const LogOutButton = chakra(ButtonPrimary, {
@@ -28,11 +31,31 @@ const LogOutButton = chakra(ButtonPrimary, {
   },
 });
 
-const sideButtonData: {
+interface ISideButton {
   label: DashboardLabel;
   icon: IconType;
   path: RoutePathDashboard;
-}[] = [
+}
+
+const tenantSideButtonData: ISideButton[] = [
+  {
+    label: DashboardLabel.Rentals,
+    icon: BsFillHouseDoorFill,
+    path: RoutePathDashboard.Rentals,
+  },
+  {
+    label: DashboardLabel.Requests,
+    icon: BsFillPersonFill,
+    path: RoutePathDashboard.Requests,
+  },
+  {
+    label: DashboardLabel.Chat,
+    icon: BsFillChatDotsFill,
+    path: RoutePathDashboard.Chat,
+  },
+];
+
+const landlordSideButtonData: ISideButton[] = [
   {
     label: DashboardLabel.Listings,
     icon: BsFillHouseDoorFill,
@@ -55,8 +78,44 @@ const sideButtonData: {
   },
 ];
 
+const sideButtonMapping = new Map<UserType | undefined, ISideButton[]>([
+  [UserType.Tenant, tenantSideButtonData],
+  [UserType.Landlord, landlordSideButtonData],
+]);
+
 const Sidebar = (props: SidebarProps) => {
   const { activeDashboardPath } = props;
+  const userTypeStore = useStore((state) => state.userType);
+  const toggleUserTypeStore = useStore((state) => state.toggleUserType);
+  const router = useRouter();
+
+  const isLandlord = userTypeStore === UserType.Landlord;
+  const sideButtonData = sideButtonMapping.get(userTypeStore) ?? [];
+  const showSideContent =
+    activeDashboardPath && activeDashboardPath !== RoutePathDashboard.Start;
+  const tab =
+    typeof router.query.tab === "string" ? router.query.tab : undefined;
+
+  const handleSwitchButton = () => {
+    const pathData = pathMapping.get(tab as RoutePathDashboard);
+
+    if (!userTypeStore || !pathData) {
+      return;
+    }
+
+    // Stay on same tab if tab exists for both tenants and landlords
+    // Otherwise, switch to a predetermined tab from the other user type
+    if (!pathData.exclusiveUserType) {
+      toggleUserTypeStore();
+    } else {
+      const nextTab =
+        userTypeStore === UserType.Tenant
+          ? RoutePathDashboard.Listings
+          : RoutePathDashboard.Rentals;
+
+      router.push(`${RoutePath.Dashboard}/${nextTab}`);
+    }
+  };
 
   return (
     <Flex
@@ -83,40 +142,54 @@ const Sidebar = (props: SidebarProps) => {
         justify="space-between"
         align="center"
       >
-        <Flex direction="column" width="100%">
-          {sideButtonData.map((sideButtonData) => (
-            <NextLink
-              key={sideButtonData.path}
-              href={`${RoutePath.Dashboard}/${sideButtonData.path}`}
-              passHref
-            >
-              <Link _hover={{ textDecoration: "none" }}>
-                <SideBarButton
-                  borderLeftColor={
-                    activeDashboardPath === sideButtonData.path
-                      ? "brand.primary"
-                      : "transparent"
-                  }
-                  background={
-                    activeDashboardPath === sideButtonData.path
-                      ? "common.dark"
-                      : "transparent"
-                  }
-                  leftIcon={
-                    <Icon
-                      as={sideButtonData.icon}
-                      width={4}
-                      height={4}
-                      marginRight="6px"
-                    />
-                  }
-                >
-                  {sideButtonData.label}
-                </SideBarButton>
-              </Link>
-            </NextLink>
-          ))}
+        <Flex direction="column" width="100%" grow={1}>
+          {showSideContent &&
+            sideButtonData.map((sideButtonData) => (
+              <NextLink
+                key={sideButtonData.path}
+                href={`${RoutePath.Dashboard}/${sideButtonData.path}`}
+                passHref
+              >
+                <Link _hover={{ textDecoration: "none" }}>
+                  <SideBarButton
+                    borderLeftColor={
+                      activeDashboardPath === sideButtonData.path
+                        ? "brand.primary"
+                        : "transparent"
+                    }
+                    background={
+                      activeDashboardPath === sideButtonData.path
+                        ? "common.dark"
+                        : "transparent"
+                    }
+                    leftIcon={
+                      <Icon
+                        as={sideButtonData.icon}
+                        width={4}
+                        height={4}
+                        marginRight="6px"
+                      />
+                    }
+                  >
+                    {sideButtonData.label}
+                  </SideBarButton>
+                </Link>
+              </NextLink>
+            ))}
         </Flex>
+        {showSideContent && (
+          <Stack mb={12} mt={8} align="center">
+            <Body2 color="white">
+              {isLandlord ? "Disable" : "Enable"} landlord view
+            </Body2>
+            <Switch
+              colorScheme="red"
+              isDisabled={!userTypeStore}
+              isChecked={isLandlord}
+              onChange={handleSwitchButton}
+            />
+          </Stack>
+        )}
         <LogOutButton borderColor="white" onClick={() => auth.signOut()}>
           Log out
         </LogOutButton>

--- a/cypress/integration/yosoko/index.spec.js
+++ b/cypress/integration/yosoko/index.spec.js
@@ -45,6 +45,8 @@ describe("From index page", () => {
     cy.get("form").submit();
 
     cy.contains("Email", { timeout: 2000 }).should("not.exist");
+    cy.contains("Landlord").click();
+    cy.contains("Go to dashboard").click();
     cy.contains("Create Listing").click();
     cy.contains("House", { timeout: 5000 });
     cy.contains("House").click();

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,8 @@
         "react-map-gl": "^6.1.11",
         "react-slick": "^0.28.1",
         "slick-carousel": "^1.8.1",
-        "use-debounce": "^7.0.1"
+        "use-debounce": "^7.0.1",
+        "zustand": "^3.6.5"
       },
       "devDependencies": {
         "@firebase/rules-unit-testing": "^1.2.6",
@@ -19850,6 +19851,22 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/zustand": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.6.5.tgz",
+      "integrity": "sha512-/WfLJuXiEJimt61KGMHebrFBwckkCHGhAgVXTgPQHl6IMzjqm6MREb1OnDSnCRiSmRdhgdFCctceg6tSm79hiw==",
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
     }
   },
   "dependencies": {
@@ -36385,6 +36402,12 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+    },
+    "zustand": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.6.5.tgz",
+      "integrity": "sha512-/WfLJuXiEJimt61KGMHebrFBwckkCHGhAgVXTgPQHl6IMzjqm6MREb1OnDSnCRiSmRdhgdFCctceg6tSm79hiw==",
+      "requires": {}
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "react-map-gl": "^6.1.11",
     "react-slick": "^0.28.1",
     "slick-carousel": "^1.8.1",
-    "use-debounce": "^7.0.1"
+    "use-debounce": "^7.0.1",
+    "zustand": "^3.6.5"
   },
   "devDependencies": {
     "@firebase/rules-unit-testing": "^1.2.6",

--- a/pages/dashboard/[tab].tsx
+++ b/pages/dashboard/[tab].tsx
@@ -12,10 +12,12 @@ import RoutePath, {
   pathMapping,
 } from "@/src/routes";
 import { useStore } from "@/src/store";
+import { getUserType } from "@/src/localStorage";
 
 function DashboardPage(): ReactElement {
   const [dashboardPath, setDashboardPath] = useState<RoutePathDashboard>();
   const router = useRouter();
+  const userTypeLS = getUserType();
   const userTypeStore = useStore((state) => state.userType);
   const setUserTypeStore = useStore((state) => state.setUserType);
 
@@ -43,10 +45,13 @@ function DashboardPage(): ReactElement {
   useEffect(() => {
     if (dashboardPath && dashboardPath !== RoutePathDashboard.Start) {
       // Defaults to Tenant user type when in ambiguous sidebar tab
-      setUserTypeStore(exclusiveUserType ?? userTypeStore ?? UserType.Tenant);
+      setUserTypeStore(
+        exclusiveUserType ?? userTypeLS ?? userTypeStore ?? UserType.Tenant
+      );
     }
   }, [
     dashboardPath,
+    userTypeLS,
     userTypeStore,
     setUserTypeStore,
     tab,

--- a/pages/dashboard/[tab].tsx
+++ b/pages/dashboard/[tab].tsx
@@ -1,70 +1,58 @@
 import React, { useEffect, useState, ReactElement } from "react";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import { DashboardLabel } from "@/src/enum";
+import { UserType } from "@/src/enum";
 import Sidebar from "@/components/sections/Sidebar";
 import DashboardHeader from "@/components/sections/DashboardHeader";
 import { Box, Grid, GridItem } from "@chakra-ui/react";
 import withAuth from "@/components/withAuth";
-import RoutePath, { RoutePathDashboard } from "@/src/routes";
-
-import ListingsView from "@/components/dashboard/ListingsView";
-import TenantsView from "@/components/dashboard/TenantsView";
-import ChatView from "@/components/dashboard/ChatView";
-import CreateListingView from "@/components/dashboard/CreateListingView";
-import RequestView from "@/components/dashboard/RequestView";
-
-const pathData: {
-  [key in RoutePathDashboard]: {
-    label: DashboardLabel;
-    content: ReactElement;
-  };
-} = {
-  [RoutePathDashboard.Listings]: {
-    label: DashboardLabel.Listings,
-    content: <ListingsView />,
-  },
-  [RoutePathDashboard.Tenants]: {
-    label: DashboardLabel.Tenants,
-    content: <TenantsView />,
-  },
-  [RoutePathDashboard.Requests]: {
-    label: DashboardLabel.Requests,
-    content: <RequestView />,
-  },
-  [RoutePathDashboard.Chat]: {
-    label: DashboardLabel.Chat,
-    content: <ChatView />,
-  },
-  [RoutePathDashboard.Create]: {
-    label: DashboardLabel.Create,
-    content: <CreateListingView />,
-  },
-};
-
-const pathList = Object.values(RoutePathDashboard);
+import RoutePath, {
+  RoutePathDashboard,
+  pathList,
+  pathMapping,
+} from "@/src/routes";
+import { useStore } from "@/src/store";
 
 function DashboardPage(): ReactElement {
-  const [dashboardPath, setDashboardPath] = useState(
-    RoutePathDashboard.Listings
-  );
+  const [dashboardPath, setDashboardPath] = useState<RoutePathDashboard>();
   const router = useRouter();
-  const { content, label } = pathData[dashboardPath];
+  const userTypeStore = useStore((state) => state.userType);
+  const setUserTypeStore = useStore((state) => state.setUserType);
+
+  const pathData = pathMapping.get(dashboardPath);
+  const Content = pathData?.content;
+  const label = pathData?.label;
+  const exclusiveUserType = pathData?.exclusiveUserType;
+
+  const tab =
+    typeof router.query.tab === "string" ? router.query.tab : undefined;
+  const tabLowercase = tab?.toLowerCase();
 
   useEffect(() => {
-    const tab =
-      typeof router.query.tab === "string" ? router.query.tab : undefined;
-
     if (tab) {
       if (pathList.includes(tab as RoutePathDashboard)) {
         setDashboardPath(tab as RoutePathDashboard);
-      } else if (pathList.includes(tab.toLowerCase() as RoutePathDashboard)) {
-        router.push(`${RoutePath.Dashboard}/${tab.toLowerCase()}`);
+      } else if (pathList.includes(tabLowercase as RoutePathDashboard)) {
+        router.push(`${RoutePath.Dashboard}/${tabLowercase}`);
       } else {
-        router.push(`${RoutePath.Dashboard}/${RoutePathDashboard.Listings}`);
+        router.push(`${RoutePath.Dashboard}/${RoutePathDashboard.Start}`);
       }
     }
-  }, [router, router.query]);
+  }, [router, router.query, tab, tabLowercase]);
+
+  useEffect(() => {
+    if (dashboardPath && dashboardPath !== RoutePathDashboard.Start) {
+      // Defaults to Tenant user type when in ambiguous sidebar tab
+      setUserTypeStore(exclusiveUserType ?? userTypeStore ?? UserType.Tenant);
+    }
+  }, [
+    dashboardPath,
+    userTypeStore,
+    setUserTypeStore,
+    tab,
+    tabLowercase,
+    exclusiveUserType,
+  ]);
 
   return (
     <>
@@ -91,7 +79,7 @@ function DashboardPage(): ReactElement {
 
         <GridItem rowSpan={3} height="100%" background="#F9FBFD" padding="4rem">
           <Box maxWidth="1640px" marginX="auto">
-            {content}
+            {Content && <Content />}
           </Box>
         </GridItem>
       </Grid>

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -8,7 +8,7 @@ function DashboardIndex(): ReactElement {
   const router = useRouter();
 
   useEffect(() => {
-    router.push(`${RoutePath.Dashboard}/${RoutePathDashboard.Listings}`);
+    router.push(`${RoutePath.Dashboard}/${RoutePathDashboard.Start}`);
   }, [router]);
 
   return <LoadingScreen />;

--- a/src/enum.ts
+++ b/src/enum.ts
@@ -1,7 +1,14 @@
 export enum DashboardLabel {
+  Start = "",
   Listings = "Listings",
   Tenants = "Tenants",
   Chat = "Chat",
   Create = "Create Listing",
-  Requests = "Requests"
+  Requests = "Requests",
+  Rentals = "Rentals",
+}
+
+export enum UserType {
+  Tenant = "tenant",
+  Landlord = "landlord",
 }

--- a/src/localStorage.ts
+++ b/src/localStorage.ts
@@ -1,0 +1,8 @@
+import { UserType } from "@/src/enum";
+
+export enum LocalStorageKey {
+  UserType = "yokoso.userType",
+}
+
+export const getUserType = () =>
+  window.localStorage.getItem(LocalStorageKey.UserType) as UserType | null;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,3 +1,13 @@
+import { FunctionComponent } from "react";
+import { DashboardLabel, UserType } from "@/src/enum";
+import StartView from "@/components/dashboard/StartView";
+import ListingsView from "@/components/dashboard/ListingsView";
+import TenantsView from "@/components/dashboard/TenantsView";
+import ChatView from "@/components/dashboard/ChatView";
+import CreateListingView from "@/components/dashboard/CreateListingView";
+import RequestView from "@/components/dashboard/RequestView";
+import RentalView from "@/components/dashboard/RentalView";
+
 enum RoutePath {
   Home = "/",
   Search = "/search",
@@ -6,11 +16,77 @@ enum RoutePath {
 }
 
 export enum RoutePathDashboard {
+  Start = "_",
   Listings = "listings",
   Tenants = "tenants",
   Chat = "chat",
   Create = "create",
   Requests = "requests",
+  Rentals = "rentals",
 }
+
+interface IPathData {
+  label: DashboardLabel;
+  content: FunctionComponent;
+  exclusiveUserType?: UserType;
+}
+
+export const pathMapping = new Map<RoutePathDashboard | undefined, IPathData>([
+  [
+    RoutePathDashboard.Start,
+    {
+      label: DashboardLabel.Start,
+      content: StartView,
+    },
+  ],
+  [
+    RoutePathDashboard.Listings,
+    {
+      label: DashboardLabel.Listings,
+      content: ListingsView,
+      exclusiveUserType: UserType.Landlord,
+    },
+  ],
+  [
+    RoutePathDashboard.Tenants,
+    {
+      label: DashboardLabel.Tenants,
+      content: TenantsView,
+      exclusiveUserType: UserType.Landlord,
+    },
+  ],
+  [
+    RoutePathDashboard.Requests,
+    {
+      label: DashboardLabel.Requests,
+      content: RequestView,
+    },
+  ],
+  [
+    RoutePathDashboard.Create,
+    {
+      label: DashboardLabel.Create,
+      content: CreateListingView,
+      exclusiveUserType: UserType.Landlord,
+    },
+  ],
+  [
+    RoutePathDashboard.Rentals,
+    {
+      label: DashboardLabel.Rentals,
+      content: RentalView,
+      exclusiveUserType: UserType.Tenant,
+    },
+  ],
+  [
+    RoutePathDashboard.Chat,
+    {
+      label: DashboardLabel.Chat,
+      content: ChatView,
+    },
+  ],
+]);
+
+export const pathList = Object.values(RoutePathDashboard);
 
 export default RoutePath;

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,38 @@
+import create from "zustand";
+import { UserType } from "@/src/enum";
+import { LocalStorageKey } from "@/src/localStorage";
+
+type State = {
+  userType: UserType | undefined;
+  setUserType: (type: UserType) => void;
+  toggleUserType: () => void;
+  clearUserType: () => void;
+};
+
+export const useStore = create<State>((set) => ({
+  userType: undefined,
+  setUserType: (userType) => {
+    set({ userType });
+    window.localStorage.setItem(LocalStorageKey.UserType, userType);
+  },
+  toggleUserType: () =>
+    set((state) => {
+      let { userType } = state;
+
+      if (userType === UserType.Tenant) {
+        userType = UserType.Landlord;
+      } else if (userType === UserType.Landlord) {
+        userType = UserType.Tenant;
+      }
+
+      if (userType) {
+        window.localStorage.setItem(LocalStorageKey.UserType, userType);
+      }
+
+      return { userType };
+    }),
+  clearUserType: () => {
+    set({ userType: undefined });
+    window.localStorage.removeItem(LocalStorageKey.UserType);
+  },
+}));


### PR DESCRIPTION
Lets users select between tenant and landlord views so that only the relevant tabs are shown. It saves this preference in local storage so it persists between sessions. It will explicitly ask for this when going to the dashboard on the first session.

Also, the empty "Rentals" tab for tenants is a placeholder.

Initial prompt:

![image](https://user-images.githubusercontent.com/20251243/143554249-e62c240b-95dd-4295-9b23-ff1ddc8f22a8.png)

- sidebar content and dashboard title is temporarily hidden when user is selecting initial view for a cleaner look

https://user-images.githubusercontent.com/20251243/143551214-c90374ef-6bae-44f7-80c2-284981a14111.mp4

- prompt is asked the first time
- user is able to toggle views (with changes in the table too, like with the Requests tab)
- only relevant tabs/info is shown

https://user-images.githubusercontent.com/20251243/143553605-75c4c4c7-c70f-4d9e-8ffd-4f7dde367651.mp4

- preference is seen persisting between sessions/refreshes