### PR TITLE
Hide divider when no additional utilities or feature exist

### DIFF
--- a/pages/listings/[id].tsx
+++ b/pages/listings/[id].tsx
@@ -240,9 +240,8 @@ function ListingPage(
                 </Grid>
               </Stack>
             </Box>
-            <Divider />
             {featureDescription && (
-              <Box>
+              <Box paddingTop="2rem">
                 <Heading5 marginBottom="2rem">Additional Amenities</Heading5>
                 {featureDescription.length > maxDescriptionCharacters ? (
                   <Box>
@@ -288,9 +287,8 @@ function ListingPage(
                 </Grid>
               </Stack>
             </Box>
-            <Divider />
             {utilitiesDescription && (
-              <Box>
+              <Box paddingTop="2rem">
                 <Heading5 marginBottom="2rem">Additional Utilities</Heading5>
                 {utilitiesDescription.length > maxDescriptionCharacters ? (
                   <Box>


### PR DESCRIPTION
Extra dividers are visible when there are no additional features or additional utilities
![image](https://user-images.githubusercontent.com/43283387/143832742-d93b6598-145d-4130-97eb-11ba7151a057.png)

Deleted dividers within sections and replaced with simple padding
![image](https://user-images.githubusercontent.com/43283387/143832905-aa23a545-deeb-4904-a1b0-dc4db44f7930.png)
