### PR TITLE
Updated Listing Search

### DIFF
--- a/.firebase/firestore.indexes.json
+++ b/.firebase/firestore.indexes.json
@@ -71,6 +71,20 @@
           "order": "ASCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "listings",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "visibility",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "lease.price",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/components/core/SearchInput.tsx
+++ b/components/core/SearchInput.tsx
@@ -31,7 +31,9 @@ function SearchInput(props: SearchInputProps): ReactElement {
     router.push({
       pathname: RoutePath.Search,
       query: {
+        bbox: result.bbox,
         center: result.center,
+        type: result.place_type,
         place: result.place_name,
         text: result.text,
       },

--- a/cypress/integration/yosoko/index.spec.js
+++ b/cypress/integration/yosoko/index.spec.js
@@ -90,7 +90,7 @@ describe("From index page", () => {
   context("with Vancouver searched", () => {
     beforeEach(() => {
       cy.visit(
-        "http://localhost:3000/search?center=-123.113953&center=49.260872&place=Vancouver%2C+British+Columbia%2C+Canada&text=Vancouver"
+        "http://localhost:3000/search?bbox=-123.224221806&bbox=49.198533909&bbox=-123.022935527&bbox=49.314078994&center=-123.113953&center=49.260872&type=place&place=Vancouver%2C+British+Columbia%2C+Canada&text=Vancouver"
       );
       cy.intercept(
         "POST",

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -220,15 +220,21 @@ function SearchPage(): ReactElement {
   const [snapshot] = useCollectionOnce(query);
   const listings = snapshot?.docs
     .filter((doc) => {
+      const { location } = doc.data();
       if (bbox) {
-        const long = doc.data().location.coordinate.longitude;
-        const lat = doc.data().location.coordinate.latitude;
+        const long = location.coordinate.longitude;
+        const lat = location.coordinate.latitude;
 
         return (
           long >= bbox[0] && lat >= bbox[1] && long <= bbox[2] && lat <= bbox[3]
         );
       }
-      return true;
+      console.log(place);
+      return (
+        place?.includes(location.country) &&
+        place.includes(location.province) &&
+        place.includes(location.cityName)
+      );
     })
     .map((doc) => {
       return ({

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -158,8 +158,23 @@ function SearchPage(): ReactElement {
 
   const router = useRouter();
   const { center } = router.query;
+  const { bbox } = router.query;
+  const type = getQueryValue(router.query, "type");
   const place = getQueryValue(router.query, "place");
-  const text = getQueryValue(router.query, "text")?.toLowerCase();
+  const text = getQueryValue(router.query, "text");
+
+  const buildQuery = (searchType?: string) => {
+    switch (searchType) {
+      case "address":
+        return "location.address";
+      case "postal code":
+        return "location.postalCode";
+      case "place":
+        return "location.cityName";
+      default:
+        return "location.address";
+    }
+  };
 
   // Query uses composite indexes
   const query = useMemo(() => {
@@ -167,7 +182,12 @@ function SearchPage(): ReactElement {
       return undefined;
     }
 
-    let query = listingsCollection.where("location.cityKey", "==", text);
+    let query = listingsCollection.where("visibility", "==", "public");
+
+    if (!bbox) {
+      const addressQuery = buildQuery(type);
+      query = query.where(addressQuery, "==", text);
+    }
 
     if (isPriceFilterActive) {
       const [minPrice, maxPrice] = priceFilterDebounced;
@@ -198,13 +218,24 @@ function SearchPage(): ReactElement {
     bathrooms,
   ]);
   const [snapshot] = useCollectionOnce(query);
-  const listings = snapshot?.docs.map(
-    (doc) =>
-      (({
+  const listings = snapshot?.docs
+    .filter((doc) => {
+      if (bbox) {
+        const long = doc.data().location.coordinate.longitude;
+        const lat = doc.data().location.coordinate.latitude;
+
+        return (
+          long >= bbox[0] && lat >= bbox[1] && long <= bbox[2] && lat <= bbox[3]
+        );
+      }
+      return true;
+    })
+    .map((doc) => {
+      return ({
         ...doc.data(),
         id: doc.id,
-      } as unknown) as Listing)
-  );
+      } as unknown) as Listing;
+    });
 
   return (
     <>

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -229,7 +229,6 @@ function SearchPage(): ReactElement {
           long >= bbox[0] && lat >= bbox[1] && long <= bbox[2] && lat <= bbox[3]
         );
       }
-      console.log(place);
       return (
         place?.includes(location.country) &&
         place.includes(location.province) &&


### PR DESCRIPTION
Updated listing search to use coordinates to filter listings (max and min coordinates provided by mapbox). If the min and max coordinate cannot be found it will default to using `text` but there is a query builder that will make sure it searches the text value on the appropriate field.

Problems addressed:
- Listings that show up will be for the correct location ( Ottawa, Ohio vs, Ottawa, Ontario)
- Able to search specific addresses, neighborhoods, cities, etc.
- only shows public listings on the search
- only shows listings with valid coordinates (will have to fix the staging data)

### Screen Shots
Searching Neighborhoods
![image](https://user-images.githubusercontent.com/35239417/143987945-94697827-0c4d-41ac-b321-e9a7169ca487.png)

Ottawa, Ohio vs. Ottawa, Ontario
![image](https://user-images.githubusercontent.com/35239417/143987997-33ad49b4-ac24-414a-a17c-6f8c4e0a1ca8.png)
![image](https://user-images.githubusercontent.com/35239417/143988105-fbf4c811-0b53-4644-ace5-a2310fd33a36.png)

