### PR TITLE
Listing Page Update

### DIFF
--- a/components/sections/ListingContactCard.tsx
+++ b/components/sections/ListingContactCard.tsx
@@ -67,6 +67,9 @@ function ListingCard(props: ListingCardProps): ReactElement {
   if (disabled) {
     disabledErrorMsg = "Create an account or log in to get started";
     disabledRequestErrorMsg = "Create an account or log in to get started";
+  } else if (listing.status === "rented") {
+    disabledErrorMsg = "This listing has already been rented";
+    disabledRequestErrorMsg = "This listing has already been rented";
   } else if (isSameUser) {
     disabledErrorMsg = "Can't send a message to yourself";
     disabledRequestErrorMsg = "Can't send a tenant request to yourself";

--- a/pages/listings/[id].tsx
+++ b/pages/listings/[id].tsx
@@ -412,7 +412,12 @@ function ListingPage(
               paddingBottom={[0, 0, 0, "1in"]}
             >
               {isVisibilityToggled === "hidden" && (
-                <Card background="pink" width="100%" padding="2rem 2rem">
+                <Card
+                  background="pink"
+                  width="100%"
+                  padding="2rem 2rem"
+                  marginBottom="1rem"
+                >
                   <Stack>
                     <Heading6 textAlign="center">
                       This listing is hidden and cannot be publicly viewed.
@@ -425,7 +430,6 @@ function ListingPage(
                   </Stack>
                 </Card>
               )}
-              {isVisibilityToggled === "hidden" && <br />}
               <ListingContactCard
                 price={price}
                 availableDate={String(availability)}

--- a/pages/listings/[id].tsx
+++ b/pages/listings/[id].tsx
@@ -26,7 +26,9 @@ import {
   Stack,
   Icon,
   useToast,
+  Tooltip,
 } from "@chakra-ui/react";
+import { QuestionOutlineIcon } from "@chakra-ui/icons";
 import {
   MdOutlineBathtub,
   MdOutlineOutdoorGrill,
@@ -50,8 +52,10 @@ import { Listing } from "@/src/api/types";
 import { auth } from "@/src/firebase";
 import { useAuthState } from "react-firebase-hooks/auth";
 import FireStoreParser from "firestore-parser";
-import { listingsRest } from "@/src/api/collections";
-import { listings as listingsCollection } from "@/src/api/collections";
+import {
+  listingsRest,
+  listings as listingsCollection,
+} from "@/src/api/collections";
 
 export const getServerSideProps = async (
   context: GetServerSidePropsContext
@@ -153,12 +157,6 @@ function ListingPage(
     ["naturalGas", GiHeatHaze],
   ]);
 
-  const statusMap = new Map([
-    ["available", "green.400"],
-    ["pending", "yellow.600"],
-    ["rented", "red.400"],
-  ]);
-
   const toast = useToast();
   const toggleVisibility = visibility === "public" ? "hidden" : "public";
   const publicSuccessMsg = "Listing was successfully made public";
@@ -226,12 +224,27 @@ function ListingPage(
                 <Caption>{country}</Caption>
               </HStack>
               <Heading4 marginBottom="4px">{title}</Heading4>
-              {user && listing.owner.uid === user.uid && (
+              {(status === "pending" || status === "rented") && (
                 <HStack>
                   <Heading5 marginBottom="8px">Listing status:</Heading5>
-                  <Heading5 marginBottom="8px" color={statusMap.get(status)}>
+                  <Heading5
+                    marginBottom="8px"
+                    color={status === "pending" ? "yellow.600" : "red.400"}
+                  >
                     {camelToSentence(status)}
                   </Heading5>
+                  <Tooltip
+                    label={
+                      status === "pending"
+                        ? "There are offers for this listing"
+                        : "A listing offer has been accepted"
+                    }
+                    fontSize="md"
+                    hasArrow
+                    closeDelay={500}
+                  >
+                    <QuestionOutlineIcon boxSize="20px" marginBottom="5px" />
+                  </Tooltip>
                 </HStack>
               )}
               <HStack>


### PR DESCRIPTION
- Added more exact address
- listing status for owners
- warning card when listing is hidden and option to make the listing public

![image](https://user-images.githubusercontent.com/43283387/144725692-f23ec58c-9f8c-4981-8058-664aa93b8f27.png)

Listing status is displayed if it is in a status over than available.

![image](https://user-images.githubusercontent.com/43283387/144725879-09641b4f-5ef7-40b6-910b-3a33f79e6434.png)

Archived listing with rented status is displayed if the owner decides to make a past listing public while disabling contact card.